### PR TITLE
fix bearer token format, needed for the ARO kubeconfig issue

### DIFF
--- a/src/arcaflow_lib_kubernetes/convert.py
+++ b/src/arcaflow_lib_kubernetes/convert.py
@@ -365,10 +365,10 @@ def connect(connection: ConnectionParameters) -> client.ApiClient:
 
     config.username = connection.username
     config.password = connection.password
-    config.api_key_prefix = "Bearer"
+    config.api_key_prefix = {}
 
     if connection.bearer_token is not None:
-        config.api_key = connection.bearer_token
+        config.api_key = {'authorization':'Bearer'+' '+connection.bearer_token} 
 
     if connection.bearer_token_file is not None:
         try:

--- a/src/arcaflow_lib_kubernetes/convert.py
+++ b/src/arcaflow_lib_kubernetes/convert.py
@@ -365,10 +365,10 @@ def connect(connection: ConnectionParameters) -> client.ApiClient:
 
     config.username = connection.username
     config.password = connection.password
-    config.api_key_prefix = {}
+    config.api_key_prefix = {"authorization": "Bearer"}
 
     if connection.bearer_token is not None:
-        config.api_key = {'authorization':'Bearer'+' '+connection.bearer_token} 
+        config.api_key = {'authorization': connection.bearer_token}  
 
     if connection.bearer_token_file is not None:
         try:


### PR DESCRIPTION
## Changes introduced with this PR

This PR fixes the format of the config.api_key field which holds the bearer token. 
The kubernetes.client.configuration.api_key expects a dictionary, which needs to look like this : {'authorization': 'Bearer sha256~dB7FEkj1ojYgIQ-zeCz2Q-fKnTYJC7d3z-20...'}. It also expects that the kubernetes.client.configuration.api_key_prefix is a dictionary and not a string. 
The connect function in this repository was setting the api_key and api_key_prefix fields as strings.  

This issue fixes #6 

I have tested this fix on an ARO cluster by creating a simple script which invokes the KrknLibKubernetes class. 
kubecli = KrknLibKubernetes(kubeconfig_path=kubeconfig_path).
I cloned the v0.1.0 of krkn-lib-kubernetes repo which has this bug.  
I modified the krkn-lib-kubernetes/client.py to use a local version of the arcaflow-lib-kubernetes-python repo with this fix. 

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).